### PR TITLE
demo of RRN filtering

### DIFF
--- a/octave/gen_rn_coeffs.m
+++ b/octave/gen_rn_coeffs.m
@@ -1,0 +1,40 @@
+% gen_rn_coeffs.m
+% David Rowe 13 april 2012
+%
+% Generate root raised cosine (Root Nyquist) filter coefficients
+% thanks http://www.dsplog.com/db-install/wp-content/uploads/2008/05/raised_cosine_filter.m
+
+function coeffs = gen_rn_coeffs(alpha, T, Rs, Nsym, M)
+
+  Ts = 1/Rs;
+
+  n = -Nsym*Ts/2:T:Nsym*Ts/2;
+  Nfilter = Nsym*M;
+  Nfiltertiming = M+Nfilter+M;
+
+  sincNum = sin(pi*n/Ts); % numerator of the sinc function
+  sincDen = (pi*n/Ts);    % denominator of the sinc function
+  sincDenZero = find(abs(sincDen) < 10^-10);
+  sincOp = sincNum./sincDen;
+  sincOp(sincDenZero) = 1; % sin(pix/(pix) =1 for x =0
+
+  cosNum = cos(alpha*pi*n/Ts);
+  cosDen = (1-(2*alpha*n/Ts).^2);
+  cosDenZero = find(abs(cosDen)<10^-10);
+  cosOp = cosNum./cosDen;
+  cosOp(cosDenZero) = pi/4;
+  gt_alpha5 = sincOp.*cosOp;
+  Nfft = 4096;
+  GF_alpha5 = fft(gt_alpha5,Nfft)/M;
+
+  % sqrt causes stop band to be amplified, this hack pushes it down again
+
+  for i=1:Nfft
+    if (abs(GF_alpha5(i)) < 0.02)
+      GF_alpha5(i) *= 0.001;
+    endif
+  end
+  GF_alpha5_root = sqrt(abs(GF_alpha5)) .* exp(j*angle(GF_alpha5));
+  ifft_GF_alpha5_root = ifft(GF_alpha5_root);
+  coeffs = real((ifft_GF_alpha5_root(1:Nfilter)));
+endfunction

--- a/octave/test_filter.m
+++ b/octave/test_filter.m
@@ -1,0 +1,19 @@
+% test_filter.m
+% test Root Nyquist (Rasised Root Cosine) filter
+
+M = 5; Nsym = 10; Fs = 8000; Rs = 1600; alpha = 0.31;
+hs = gen_rn_coeffs(alpha, 1.0/Fs, Rs, Nsym, 5);
+
+Nsymbols = 100; Nsamples = Nsymbols*M;
+
+% QPSK symbols
+tx_sym = 1 - 2*(rand(1,Nsymbols) > 0.5) + j*(1 - 2*(rand(1,Nsymbols) > 0.5));
+
+tx_sym_zero_pad = zeros(1,Nsamples);
+tx_sym_zero_pad(1:M:end) = tx_sym;
+tx_samples = filter(hs,1,tx_sym_zero_pad);
+rx_samples = filter(hs,1,tx_samples);
+rx_symbols = rx_samples(1:M:end);
+
+% scatter plot - discard the first few symbols as filter memory is filling
+plot(rx_symbols(2*Nsym:end), '+');


### PR DESCRIPTION
Hi @srsampson - simple Octave demo to show what I mean by zero padding input.  Plotting the scatter diagram is also a good way to test your FIR filtering.  Looks like the coeffs are doing the right thing.

```
octave:97> test_filter
```
![Screenshot from 2020-10-20 07-16-18](https://user-images.githubusercontent.com/45574645/96509875-3b137700-12a4-11eb-8fa6-ee6ab2336401.png)
