### PR TITLE
manual makefile and scatter diagram test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for singe carrier QPSK modem
+# Makefile for single carrier QPSK modem
 
 SRC=src/qpsk.c src/filter.c
 HEADER=headers/filter_coef.h  headers/filter.h  headers/qpsk.h

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# Makefile for singe carrier QPSK modem
+
+SRC=src/qpsk.c src/filter.c
+HEADER=headers/filter_coef.h  headers/filter.h  headers/qpsk.h
+
+qpsk: ${SRC} ${HEADER}
+	gcc -Iheaders ${SRC} -DTEST_SCATTER -o qpsk -Wall -lm
+
+# generate scatter diagram PNG
+test_scatter: qpsk
+	./qpsk 2>scatter.txt
+	DISPLAY="" octave-cli -qf --eval "load scatter.txt; plot(scatter(1:1000,1),scatter(1:1000,2),'+'); print('scatter.png','-dpng')"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ The design is driven by the FreeDV 2020 Specifications which were originally des
 #### Development
 Currently working on the low level code. The modulation/demodulation seems to work, but I have to transmit and receive I+Q. I'm using the Quisk complex filter for the matched raised cosine coefficients. It appears to be working.
 
-#### Building
+#### Building from git clone & scatter diagram tests
+
+```
+$ make test_scatter
+```
+Then view `scatter.png`
+
+#### Building from export-qpsk.zip
 To build the project, unzip the ```export-qpsk.zip``` file into an empty directory, ```cd qpsk``` into it, and type ```Make``` and it will build the project, leaving the compiled file in ```dist/Debug/GNU-Linux/``` directory.
 
 This is based on its Netbeans 8.2 IDE I use for building.

--- a/src/qpsk.c
+++ b/src/qpsk.c
@@ -200,6 +200,9 @@ void rx_frame(int16_t in[], int bits[], FILE *fout) {
     for (int i = 0; i < (FRAME_SIZE / CYCLES); i++) {
         decimated_frame[i] = decimated_frame[(FRAME_SIZE / CYCLES) + i];
         decimated_frame[(FRAME_SIZE / CYCLES) + i] = bpfilt[(i * CYCLES)];
+#ifdef TEST_SCATTER
+        fprintf(stderr,"%f %f\n", crealf(decimated_frame[(FRAME_SIZE / CYCLES) + i]), cimagf(decimated_frame[(FRAME_SIZE / CYCLES) + i]));
+#endif        
     }
 
     int dibit[2];


### PR DESCRIPTION
Hi Steve,

I've added a hand generated Makefile to support a scatter diagram test I'm building up (you don't have to keep it - I can see there is another Malkefile in the zip file).

Here is the scatter diagram I'm getting:

![scatter](https://user-images.githubusercontent.com/45574645/96837560-298dc300-148e-11eb-9220-334d92946574.png)

I'm guessing you are 1 sample off the ideal timing instant, and there's a bit of a phase offset too.